### PR TITLE
Add nixos user to trusted-users

### DIFF
--- a/formats/qcow2.nix
+++ b/formats/qcow2.nix
@@ -22,6 +22,7 @@ let
         settings = {
           auto-optimise-store = true;
           experimental-features = [ "nix-command" "flakes" ];
+          trusted-users = [ "nixos" ];
         };
       };
 

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -11,6 +11,7 @@
     settings = {
       auto-optimise-store = true;
       experimental-features = [ "nix-command" "flakes" ];
+      trusted-users = [ "nixos" ];
     };
   };
 


### PR DESCRIPTION
Resolves #5.
Allows remote `nixos-rebuild switch --target remote` to just work without having to run `nixos-rebuild switch` on the remote host.
This is valuable for remote hosts with limited resources as the build process happens locally and has no chance of causing OOM crashes or disrupting production processes.
I don't believe there are any security implications to this change as the nixos user already has passwordless sudo.